### PR TITLE
Unnecessary boolean checkup?

### DIFF
--- a/src/pages/protected-page.js
+++ b/src/pages/protected-page.js
@@ -7,14 +7,8 @@ export const ProtectedPage = () => {
   const [message, setMessage] = useState("");
 
   useEffect(() => {
-    let isMounted = true;
-
     const getMessage = async () => {
       const { data, error } = await getProtectedResource();
-
-      if (!isMounted) {
-        return;
-      }
 
       if (data) {
         setMessage(JSON.stringify(data, null, 2));
@@ -26,10 +20,6 @@ export const ProtectedPage = () => {
     };
 
     getMessage();
-
-    return () => {
-      isMounted = false;
-    };
   }, []);
 
   return (


### PR DESCRIPTION
I'm currently reading the "[React Authentication By Example](https://developer.auth0.com/resources/guides/spa/react/basic-authentication#get-user-profile-information-in-react)" article and questioning the need for the `let isMounted = true` statement. Since `isMounted` will always be true, I'm unsure if it is required.  The same statement can also be found in `src/pages/admin-page.js` and `src/pages/public-page.js`.